### PR TITLE
Adiciona possibilidade de escolher o timeout do bulk

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Essas são as envs que o cóidigo precisa para rodar:
 ### Envs comuns aos projetos
 
 * ASGARD_LOGINGESTOR_LOGLEVEL: Log level que o código usará em seus logs: Valores possíveis são os levels do Python: "INFO", "ERROR", ...
+* INDEXER_BULK_INSERT_TIMEOUT: Timeout máximo nas comunicações de bulk insert do elasticsearch
 
 ## Trabalhos futuros
 

--- a/logingestor/conf.py
+++ b/logingestor/conf.py
@@ -21,6 +21,7 @@ loop = asyncio.get_event_loop()
 init_logger_task = loop.create_task(init_logger())
 
 ELASTIC_SEARCH_ADDRESSES = get_option("ELASTICSEARCH", "ADDRESS")
+BULK_INSERT_TIMEOUT = int(os.getenv("INDEXER_BULK_INSERT_TIMEOUT", "30"))
 
 elasticsearch = Elasticsearch(hosts=ELASTIC_SEARCH_ADDRESSES)
 

--- a/logingestor/indexer.py
+++ b/logingestor/indexer.py
@@ -2,6 +2,7 @@ from typing import List
 from datetime import datetime, timezone, timedelta
 
 from asyncworker.rabbitmq.message import RabbitMQMessage
+from logingestor import conf
 
 class Indexer:
 
@@ -22,7 +23,7 @@ class Indexer:
         for doc in documents:
             _bulk.append({ "index" : { "_index" : self._index_name(doc.body), "_type" : "logs"}})
             _bulk.append(self._prepare_document(doc.body))
-        result = await self.elasticsearch.bulk(_bulk)
+        result = await self.elasticsearch.bulk(_bulk, request_timeout=conf.BULK_INSERT_TIMEOUT)
 
         if result["errors"]:
             for idx, item in enumerate(result['items']):

--- a/logingestor/routes.py
+++ b/logingestor/routes.py
@@ -12,7 +12,7 @@ app = App(host=conf.RABBITMQ_HOST, user=conf.RABBITMQ_USER, password=conf.RABBIT
 
 indexer = AppIndexer(conf.elasticsearch, conf.logger)
 
-async def logger_function(total_messages, name, elapsed_time, **kwargs):
+async def logger_function(total_messages, name, elapsed_time, *args, **kwargs):
     await conf.logger.info({name: elapsed_time, "total-messages": total_messages, **kwargs})
 
 @app.route(conf.LOGS_QUEUE_NAMES, vhost=conf.RABBITMQ_VHOST, options = {Options.BULK_SIZE: conf.LOGS_BULK_SIZE})

--- a/tests/conf_test.py
+++ b/tests/conf_test.py
@@ -7,6 +7,13 @@ from asynctest import mock
 from logingestor import conf
 
 
+class CommonConfTest(asynctest.TestCase):
+
+    def test_load_bulk_timeout_as_integer(self):
+        with mock.patch.dict(os.environ, INDEXER_BULK_INSERT_TIMEOUT="60"):
+            importlib.reload(conf)
+            self.assertEqual(60, conf.BULK_INSERT_TIMEOUT)
+
 class StatsIndexerConfTest(asynctest.TestCase):
 
     def test_test_read_correct_configs(self):

--- a/tests/test_logindexer_routes.py
+++ b/tests/test_logindexer_routes.py
@@ -22,7 +22,7 @@ class RoutesTest(asynctest.TestCase):
             ]
             await routes.generic_app_log_indexer(messages)
             self.assertEqual(messages, list(indexer_bulk_mock.await_args_list[0][0][0]))
-            logger_function_mock.assert_awaited_with(2, "processing-time", mock.ANY)
+            logger_function_mock.assert_awaited_with(2, "processing-time", mock.ANY, mock.ANY, mock.ANY, mock.ANY)
 
     async def test_app_uses_right_configs(self):
 
@@ -53,6 +53,6 @@ class RoutesTest(asynctest.TestCase):
             conf.logger = logger_mock
             await routes.generic_app_log_indexer(messages)
             self.assertEqual(logger_mock, routes.indexer.logger)
-            logger_function_mock.assert_awaited_with(1, "processing-time", mock.ANY)
+            logger_function_mock.assert_awaited_with(1, "processing-time", mock.ANY, mock.ANY, mock.ANY, mock.ANY)
 
 

--- a/tests/test_logindexer_routes.py
+++ b/tests/test_logindexer_routes.py
@@ -22,7 +22,9 @@ class RoutesTest(asynctest.TestCase):
             ]
             await routes.generic_app_log_indexer(messages)
             self.assertEqual(messages, list(indexer_bulk_mock.await_args_list[0][0][0]))
-            logger_function_mock.assert_awaited_with(2, "processing-time", mock.ANY, mock.ANY, mock.ANY, mock.ANY)
+
+            positional_arguments_of_first_call = logger_function_mock.await_args_list[0][0]
+            self.assertEqual((2, "processing-time", mock.ANY), positional_arguments_of_first_call[:3])
 
     async def test_app_uses_right_configs(self):
 
@@ -53,6 +55,7 @@ class RoutesTest(asynctest.TestCase):
             conf.logger = logger_mock
             await routes.generic_app_log_indexer(messages)
             self.assertEqual(logger_mock, routes.indexer.logger)
-            logger_function_mock.assert_awaited_with(1, "processing-time", mock.ANY, mock.ANY, mock.ANY, mock.ANY)
+            positional_arguments_of_first_call = logger_function_mock.await_args_list[0][0]
+            self.assertEqual((1, "processing-time", mock.ANY), positional_arguments_of_first_call[:3])
 
 


### PR DESCRIPTION
Dessa forma poderemos fazer bulks maiores que levam mais do que
os 10s default do timeout do elasticsearch client.